### PR TITLE
Focus the iframe content window.

### DIFF
--- a/WebExtension/data/reader/index.js
+++ b/WebExtension/data/reader/index.js
@@ -69,6 +69,7 @@ body {
     iframe.contentDocument.body.dataset.mode = prefs.mode;
     document.body.dataset.mode = prefs.mode;
     styles.textContent = prefs['user-css'];
+    iframe.contentWindow.focus();
   });
 }
 


### PR DESCRIPTION
Make the iframe focus after reader loaded,
so users can use `Space` key to scroll the page down.