### PR TITLE
Chinese is not a RTL script

### DIFF
--- a/WebExtension/firefox/data/inject/wrapper.js
+++ b/WebExtension/firefox/data/inject/wrapper.js
@@ -77,10 +77,10 @@ function getSelectionHTML() {
   ).parse();
   article.url = article.url || location.href;
 
-  // https://get.foundation/sites/docs/rtl.html
+  // https://www.w3.org/International/questions/qa-scripts.en#directions
   if (article.dir === null) {
     const lang = document.documentElement.lang;
-    if (lang && ['ar', 'zh', 'fa', 'he', 'iw', 'ur', 'yi', 'ji'].some(a => lang.indexOf(a) !== -1)) {
+    if (lang && ['ar', 'fa', 'he', 'iw', 'ur', 'yi', 'ji'].some(a => lang.indexOf(a) !== -1)) {
       article.dir = 'rtl';
     }
   }


### PR DESCRIPTION
The information in the original referred link is WRONG. Chinese (zh) is not a RTL script.

I have replace the link with a more updated W3C document.