### PR TITLE
Fix watson voices not changing

### DIFF
--- a/v3/data/reader/libs/text-to-speech/engines/watson.js
+++ b/v3/data/reader/libs/text-to-speech/engines/watson.js
@@ -31,7 +31,7 @@
 
   // eslint-disable-next-line no-inner-declarations
   async function build(text) {
-    const sessionID = await guid(text);
+    const sessionID = await guid(text + this.key);
 
     if (n.has(sessionID)) {
       return n.get(sessionID);


### PR DESCRIPTION
When changing the watson voice on text that has already been read, the old audio with the old voice plays instead of requesting a new one