### PR TITLE
Add Japanese (ja) localization

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ package.json
 .idea/
 node_modules/
 .vscode/
+_work/

--- a/v3/_locales/ja/messages.json
+++ b/v3/_locales/ja/messages.json
@@ -1,0 +1,68 @@
+{
+  "description": {
+    "message": "ボタンや背景などの不要な要素を取り除き、テキストサイズ・コントラスト・レイアウトを調整して読みやすくします"
+  },
+  "rd_printing": {
+    "message": "リーダービューで印刷 (command)"
+  },
+  "rd_screenshot": {
+    "message": "現在のビューのスクリーンショットを撮影 (command)"
+  },
+  "rd_email": {
+    "message": "メールで送信 (command)"
+  },
+  "rd_save": {
+    "message": "HTML形式でコピーを保存 (command)\n\nAltキー：メモを除外\nShiftキー：MarkDownに変換\nCtrl/Commandキー：クリップボードにコピー（マウスのみ）"
+  },
+  "rd_fullscreen": {
+    "message": "全画面表示に切り替え (command)"
+  },
+  "rd_design": {
+    "message": "デザインモードを切り替え (command)\n\n有効時はMS Wordのように文書の編集や要素の削除が可能です\n\nCtrl/Command + B: 太字のオン/オフ\nCtrl/Command + I: イタリックのオン/オフ\nCtrl/Command + U: 下線のオン/オフ"
+  },
+  "rd_speech": {
+    "message": "記事を読み上げ (command)\n途中から開始するには、開始位置の単語を選択してからボタンを押してください"
+  },
+  "rd_images": {
+    "message": "画像の表示/非表示 (command)"
+  },
+  "rd_note": {
+    "message": "付箋メモを追加 (command)"
+  },
+  "rd_highlight": {
+    "message": "ハイライトを切り替え (command)\n\nハイライトはブラウザを再起動するまで保持されます"
+  },
+  "rd_stm": {
+    "message": "このドキュメントのすべての記事を表示"
+  },
+  "rd_sts": {
+    "message": "このドキュメントのメイン記事のみ表示"
+  },
+  "rd_warning_1": {
+    "message": "リーダーのコンテンツが利用できなくなりました。数秒後に元のページに戻ります..."
+  },
+  "rd_copied": {
+    "message": "クリップボードにコピーしました"
+  },
+  "bg_simple_mode": {
+    "message": "シンプルモードで開く"
+  },
+  "bg_reader_view": {
+    "message": "リーダービューで開く"
+  },
+  "bg_inactive_reader_view": {
+    "message": "バックグラウンドのリーダービューで開く"
+  },
+  "bg_switch_reader": {
+    "message": "リーダービューに切り替え"
+  },
+  "bg_options": {
+    "message": "オプションを開く"
+  },
+  "bg_warning_1": {
+    "message": "申し訳ありませんが、このページは変換できません。"
+  },
+  "bg_converting": {
+    "message": "ページの読み込みが完了すると変換を開始します..."
+  }
+}


### PR DESCRIPTION
This PR adds Japanese (ja) localization for the extension.

Changes:
  - All 22 strings in v3/_locales/en/messages.json have been translated
  - Translation has been reviewed by a native Japanese speaker
  - Note: Some strings are hardcoded in the source code and are outside the scope of this PR
 
Screenshots:
![03](https://github.com/user-attachments/assets/8d397427-be93-42c0-99eb-d0ef24c37e09)
![02](https://github.com/user-attachments/assets/45830282-329b-4693-a326-a49d9ee82e97)
