### PR TITLE
Fix title rendering in simple mode

### DIFF
--- a/v3/data/inject/wrapper.js
+++ b/v3/data/inject/wrapper.js
@@ -470,6 +470,7 @@ try {
   }`;
           document.head.replaceWith(head);
           const body = dom.querySelector('body');
+          body.querySelector('#reader-title').textContent = article.title || 'Unknown Title';
           body.querySelector('#reader-content').outerHTML = article.content;
           body.querySelector('#reader-credits').textContent = article.byline || '';
           body.querySelector('#reader-estimated-time').textContent =


### PR DESCRIPTION
Fixes the missing article title in v3 Simple Mode.

The Simple Mode path builds the page from `data/reader/template.html`, but unlike the normal reader view path, it was not filling the existing `#reader-title` element. As a result, the title area stayed empty even though `article.title` was available.

This patch sets `#reader-title` from `article.title`, with the same `Unknown Title` fallback used elsewhere.

I kept the change limited to the Simple Mode rendering path in `v3/data/inject/wrapper.js`.